### PR TITLE
Companion to PR puphpet/puphpet#149

### DIFF
--- a/manifests/pecl/module.pp
+++ b/manifests/pecl/module.pp
@@ -112,15 +112,6 @@ define php::pecl::module (
         path      => $path,
         require   => [ Class['php::pear'], Class['php::devel']],
       }
-      if $php::bool_augeas == true {
-        php::augeas { "augeas-${name}":
-          ensure => $ensure,
-          entry  => "PHP/extension[. = \"${name}.so\"]",
-          value  => "${name}.so",
-          notify => $manage_service_autorestart,
-          target => $config_file,
-        }
-      }
     }
   } # End Case
 }


### PR DESCRIPTION
This was a bit of a hack by the original author that is solved in a more elegant way in https://github.com/puphpet/puphpet/pull/1409. Puphpet supports a much more broad range of distros, so the code needs to go through `puphpet::php::ini` to get all the `augeas` parameters right. Leaving this code in could result in an extension being called twice.
